### PR TITLE
fixed incorrect application of transfer functions in makewavedata.m

### DIFF
--- a/private/makewavedata.m
+++ b/private/makewavedata.m
@@ -45,7 +45,8 @@ end
 %make random data
 for i=1:ndat
    for j=1:nprobes
-      eta(i,j)=sum(sum(eamp.*trf(:,:,j).*cos(layout(1,j)*wns*cos(dirs)+layout(2,j)*wns*sin(dirs)-freqmat*t(i)+randphase)));
+      kxwt=layout(1,j)*wns*cos(dirs) + layout(2,j)*wns*sin(dirs) - freqmat*t(i)+randphase;
+      eta(i,j)=sum(sum( real( eamp.*trf(:,:,j).*exp(-1i*kxwt) ) ));
    end
 end
 


### PR DESCRIPTION
It was giving incorrect results when generating synthetic wave timeseries for a datatype with a complex transfer function. For example, in cases where the transfer function for the datatype is imaginary, the output data is also imaginary. It is just multiplying by cos(wt). I think the correct way is to do a complex multiplication of the TF with exp(-iwt) and take the real part. 

You can reproduce the error with the following code: 
ID.fs=4;
ID.depth=100;
ID.datatypes={'elev','slpx','slpy','accx','accy','accz','velx','vely','velz'};
ID.layout=repmat([0 0 100]',[1 length(ID.datatypes)]);
[SM,IDout]=makespec([1/25 1/10 1/3],360,10,1,1,ID,20000,0)
d=IDout.data;
eta=d(:,1);
slpx=d(:,2);
slpy=d(:,3);
accx=d(:,4);
accy=d(:,5);
accz=d(:,6);
velx=d(:,7);
vely=d(:,8);
velz=d(:,9);
